### PR TITLE
Fix Typo and Download Link

### DIFF
--- a/_pages/articles.md
+++ b/_pages/articles.md
@@ -120,7 +120,7 @@ resulting in the most systematic and practical curriculum ever.
 
 Original: <a href="https://www.innoq.com/en/blog/isaqb-foundation-2021/" target="_blank" rel="noopener noreferrer nofollow">INNOQ Blog, April 2021</a>
 
-## Architekten: Zehnkämfer der IT
+## Architekten: Zehnkämpfer der IT
 
 Peter Hruschka, Gernot Starke, OBJEKTspektrum.
 
@@ -128,7 +128,7 @@ Wir teilen die (verbreitete) Meinung, dass Softwarearchitekten Technologie gut k
 Softwarearchitekten müssen darüber hinaus über eine Vielzahl weiterer Fähigkeiten verfügen und entsprechende Aufgaben erledigen können. 
 Die verantwortungsbewussten Über-den-Tellerrand-Gucker bilden in Projekten ein wichtiges Bindeglied zwischen unterschiedlichen Stakeholdergruppen wie Managern, Requirements-Engineers, Entwicklungsteams, Testern und Administratoren oder Hardware-Ingenieuren. 
 
-<a href="https://www.arc42.de/downloads/zehnkaempfer.pdf" target="_blank" rel="noopener noreferrer nofollow">Download (als pdf, von arc42.de)</a>
+<a href="https://www.arc42.de/downloads/Zehnkaempfer.pdf" target="_blank" rel="noopener noreferrer nofollow">Download (als pdf, von arc42.de)</a>
 
 
  


### PR DESCRIPTION
- Fix Typo in the word "Zehnkämpfer"
- Link to article-download was broken, because the actual file to download has an upper-case first letter.